### PR TITLE
Made mentor images circular

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -102,6 +102,11 @@ body {
 }
 
 .card {
+    padding-top: 10px;
+    padding-left: 10px;
+    padding-right: 10px;
+    width: 320px;
+    height: 420px;
 	position: relative;
 	background: #FFF;
 	color: #758F9B;
@@ -137,7 +142,10 @@ body {
 }
 
 .card .thumbnail {
-	min-height: 300px;
+    min-height: 300px;
+    min-width: 300px;
+    max-height: 300px;
+    max-width: 300px;
 	background-repeat: no-repeat;
 	background-position: center center;
     background-attachment: scroll;

--- a/src/styles.css
+++ b/src/styles.css
@@ -114,8 +114,10 @@ body {
 }
 
 .card .content-card {
-	padding: 20px;
-	margin-bottom: 20px;
+    /* padding: 20px; */
+    padding-top: 10px;
+    margin-bottom: 20px;
+    text-align: center;
 }
 
 .card h3 {
@@ -133,7 +135,8 @@ body {
 	min-height: 300px;
 	background-repeat: no-repeat;
 	background-position: center center;
-	background-attachment: scroll;
+    background-attachment: scroll;
+    border-radius: 50%;
 	-webkit-background-size: cover;
 	-moz-background-size: cover;
 	-o-background-size: cover;


### PR DESCRIPTION
Resolves part 2 of #15 by adding `border-radius: 50%;` to the thumbnail class.