### PR TITLE
fixed styling issue

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -71,6 +71,8 @@ i {
   max-width: 100%;
   /* height: auto; */
   height: 200px;
+  object-fit: contain;
+  object-position: center;
 }
 .App {
   text-align: center;


### PR DESCRIPTION
Regarding issue #142, I installed this locally and am not seeing this issue. When I check the image, it's set to `height: auto` and it uses the `img-fluid` class so there should not be a fixed height on it. I did see that `.mentor-img-thumbnail` had a height set to 200px, so in the event that the image is resized and does look distorted, I added `object-fit: contain` and `object-position: center` to remove the distortion.